### PR TITLE
refactor: change health endpoint to save resources on health check

### DIFF
--- a/apps/@tinie-server/src/api/health/health.controller.ts
+++ b/apps/@tinie-server/src/api/health/health.controller.ts
@@ -13,5 +13,10 @@ export const HealthController = (app: App) =>
                 detail: {
                     description: 'Returns information about the health and status of the system.',
                 },
+            })
+            .get('/db', async ({ HealthService }) => await HealthService.db(), {
+                detail: {
+                    description: 'Returns information about the health and status of the connected storage services.',
+                },
             }),
     );

--- a/apps/@tinie-server/src/api/health/health.service.ts
+++ b/apps/@tinie-server/src/api/health/health.service.ts
@@ -9,13 +9,16 @@ export const HealthService = () => {
     return {
         get: async () => {
             return {
-                server: true,
-                cache: await getCacheStatus(),
-                db: !!(await getDbStatus()),
-                zookeeper: await getZookeeperStatus(),
+                ok: true,
                 uptime: uptime(),
-                cache_ttl: process.env.REDIS_TTL,
                 version: (await import('../../../package.json')).version,
+            };
+        },
+        db: async () => {
+            return {
+                redis: await getCacheStatus(),
+                dynamodb: !!(await getDbStatus()),
+                cloudflare: await getZookeeperStatus(),
             };
         },
     };


### PR DESCRIPTION
This PR fixes #4 by changing the Health Endpoint to no longer request status from the Databases
